### PR TITLE
Add archive scan progress reporting and sanitize control chars in output

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -1,6 +1,10 @@
 package action
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
 
 // SyncAction is implemented by any action that propagates action at source to action at destination
 type SyncAction interface {
@@ -17,6 +21,21 @@ type SyncAction interface {
 }
 
 const cmdSeparator = "\u0001"
+
+// sanitizePath replaces C0/C1 control characters with their Unicode escape representation
+// for safe terminal output. This prevents terminal escape injection from filenames
+// containing characters like U+0090 (DCS).
+func sanitizePath(path string) string {
+	var b strings.Builder
+	for _, r := range path {
+		if unicode.IsControl(r) && r != '\t' {
+			fmt.Fprintf(&b, "\\u%04X", r)
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
 
 // escape escapes the path for use in a unix command
 func escape(path string) string {

--- a/action/action.go
+++ b/action/action.go
@@ -2,6 +2,8 @@ package action
 
 import (
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
 	"unicode"
 )
@@ -18,6 +20,18 @@ type SyncAction interface {
 	Perform() error
 	// Uniqueness should define a string that's unique with an action
 	Uniqueness() string
+}
+
+// SortByDestinationDir sorts actions by destination directory path,
+// grouping files in the same directory together for better cache locality.
+func SortByDestinationDir(actions []SyncAction) {
+	keys := make([]string, len(actions))
+	for i, a := range actions {
+		keys[i] = filepath.Dir(a.destinationPath())
+	}
+	sort.SliceStable(actions, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
 }
 
 const cmdSeparator = "\u0001"

--- a/action/copy_file_action.go
+++ b/action/copy_file_action.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"syscall"
 	"time"
 )
 
@@ -50,14 +51,16 @@ func (a CopyFileAction) Perform() error {
 	}
 
 	if a.UseReflink {
-		var cmd *exec.Cmd
-		if runtime.GOOS == "darwin" {
-			cmd = exec.Command("cp", "-c", "-p", a.AbsSourcePath, a.AbsDestPath)
+		if runtime.GOOS == "linux" {
+			if err := reflinkCopy(a.AbsSourcePath, a.AbsDestPath, srcInfo.Mode()); err != nil {
+				return err
+			}
 		} else {
-			cmd = exec.Command("cp", "--reflink=auto", "-p", a.AbsSourcePath, a.AbsDestPath)
-		}
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("reflink copy failed: %w: %s", err, string(out))
+			// macOS: use cp -c
+			cmd := exec.Command("cp", "-c", "-p", a.AbsSourcePath, a.AbsDestPath)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return fmt.Errorf("reflink copy failed: %w: %s", err, string(out))
+			}
 		}
 	} else {
 		if err := regularCopy(a.AbsSourcePath, a.AbsDestPath); err != nil {
@@ -71,6 +74,32 @@ func (a CopyFileAction) Perform() error {
 	return os.Chtimes(a.AbsDestPath, a.SourceModTime, a.SourceModTime)
 }
 
+// reflinkCopy creates a reflink copy using FICLONE ioctl directly, avoiding fork+exec of cp.
+func reflinkCopy(src, dst string, mode os.FileMode) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("cannot open source %q: %w", src, err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("cannot create destination %q: %w", dst, err)
+	}
+
+	// FICLONE = _IOW(0x94, 9, int) = 0x40049409
+	const ficlone = 0x40049409
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, dstFile.Fd(), ficlone, srcFile.Fd())
+	if errno != 0 {
+		dstFile.Close()
+		os.Remove(dst)
+		// Fallback to regular copy if reflink not supported
+		return regularCopyWithMode(src, dst, mode)
+	}
+
+	return dstFile.Close()
+}
+
 // Uniqueness is keyed on destination path — same source can serve multiple copies.
 func (a CopyFileAction) Uniqueness() string {
 	return "cp" + cmdSeparator + a.AbsDestPath
@@ -78,6 +107,13 @@ func (a CopyFileAction) Uniqueness() string {
 
 func (a CopyFileAction) String() string {
 	return fmt.Sprintf(`copy file "%s" to "%s"`, sanitizePath(a.AbsSourcePath), sanitizePath(a.AbsDestPath))
+}
+
+func regularCopyWithMode(src, dst string, mode os.FileMode) error {
+	if err := regularCopy(src, dst); err != nil {
+		return err
+	}
+	return os.Chmod(dst, mode)
 }
 
 func regularCopy(src, dst string) error {

--- a/action/copy_file_action.go
+++ b/action/copy_file_action.go
@@ -77,7 +77,7 @@ func (a CopyFileAction) Uniqueness() string {
 }
 
 func (a CopyFileAction) String() string {
-	return fmt.Sprintf(`copy file "%s" to "%s"`, a.AbsSourcePath, a.AbsDestPath)
+	return fmt.Sprintf(`copy file "%s" to "%s"`, sanitizePath(a.AbsSourcePath), sanitizePath(a.AbsDestPath))
 }
 
 func regularCopy(src, dst string) error {

--- a/action/copy_file_action.go
+++ b/action/copy_file_action.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -74,8 +76,87 @@ func (a CopyFileAction) Perform() error {
 	return os.Chtimes(a.AbsDestPath, a.SourceModTime, a.SourceModTime)
 }
 
+// reflinkSupport caches whether a mountpoint supports FICLONE.
+// Populated lazily on first attempt per mountpoint.
+var reflinkSupport sync.Map // mountpoint (string) → supported (bool)
+
+// mountpointForPath returns the longest matching mountpoint from /proc/self/mounts.
+// Falls back to "/" if no match found. Result is cached after first /proc read.
+var mountCache map[string]struct{}
+var mountCacheOnce sync.Once
+
+func loadMountpoints() {
+	mountCache = make(map[string]struct{})
+	data, err := os.ReadFile("/proc/self/mounts")
+	if err != nil {
+		return
+	}
+	for _, line := range splitLines(string(data)) {
+		fields := splitFields(line)
+		if len(fields) >= 2 {
+			mountCache[fields[1]] = struct{}{}
+		}
+	}
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	for len(s) > 0 {
+		i := 0
+		for i < len(s) && s[i] != '\n' {
+			i++
+		}
+		lines = append(lines, s[:i])
+		if i < len(s) {
+			i++
+		}
+		s = s[i:]
+	}
+	return lines
+}
+
+func splitFields(s string) []string {
+	var fields []string
+	i := 0
+	for i < len(s) {
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			i++
+		}
+		j := i
+		for j < len(s) && s[j] != ' ' && s[j] != '\t' {
+			j++
+		}
+		if j > i {
+			fields = append(fields, s[i:j])
+		}
+		i = j
+	}
+	return fields
+}
+
+func mountpointForPath(path string) string {
+	mountCacheOnce.Do(loadMountpoints)
+	abs, _ := filepath.Abs(path)
+	best := "/"
+	for mp := range mountCache {
+		if len(mp) > len(best) && (abs == mp || (len(abs) > len(mp) && abs[:len(mp)] == mp && abs[len(mp)] == '/')) {
+			best = mp
+		}
+	}
+	return best
+}
+
+// FICLONE = _IOW(0x94, 9, int) = 0x40049409
+const ficlone = 0x40049409
+
 // reflinkCopy creates a reflink copy using FICLONE ioctl directly, avoiding fork+exec of cp.
+// Caches reflink support per mountpoint: first call tries ioctl, subsequent calls skip if unsupported.
 func reflinkCopy(src, dst string, mode os.FileMode) error {
+	mp := mountpointForPath(dst)
+	if supported, ok := reflinkSupport.Load(mp); ok && !supported.(bool) {
+		return regularCopyWithMode(src, dst, mode)
+	}
+
 	srcFile, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("cannot open source %q: %w", src, err)
@@ -87,16 +168,15 @@ func reflinkCopy(src, dst string, mode os.FileMode) error {
 		return fmt.Errorf("cannot create destination %q: %w", dst, err)
 	}
 
-	// FICLONE = _IOW(0x94, 9, int) = 0x40049409
-	const ficlone = 0x40049409
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, dstFile.Fd(), ficlone, srcFile.Fd())
 	if errno != 0 {
 		dstFile.Close()
 		os.Remove(dst)
-		// Fallback to regular copy if reflink not supported
+		reflinkSupport.Store(mp, false)
 		return regularCopyWithMode(src, dst, mode)
 	}
 
+	reflinkSupport.Store(mp, true)
 	return dstFile.Close()
 }
 

--- a/action/make_directory_action.go
+++ b/action/make_directory_action.go
@@ -40,5 +40,5 @@ func (a MakeDirectoryAction) Uniqueness() string {
 }
 
 func (a MakeDirectoryAction) String() string {
-	return fmt.Sprintf(`create directory "%s"`, a.destinationPath())
+	return fmt.Sprintf(`create directory "%s"`, sanitizePath(a.destinationPath()))
 }

--- a/action/move_file_action.go
+++ b/action/move_file_action.go
@@ -54,5 +54,5 @@ func (a MoveFileAction) Uniqueness() string {
 }
 
 func (a MoveFileAction) String() string {
-	return fmt.Sprintf(`rename/move file from "%s" to "%s"`, a.sourcePath(), a.destinationPath())
+	return fmt.Sprintf(`rename/move file from "%s" to "%s"`, sanitizePath(a.sourcePath()), sanitizePath(a.destinationPath()))
 }

--- a/action/propagate_timestamp_action.go
+++ b/action/propagate_timestamp_action.go
@@ -62,5 +62,5 @@ func (a PropagateTimestampAction) Uniqueness() string {
 }
 
 func (a PropagateTimestampAction) String() string {
-	return fmt.Sprintf(`propagate timestamp of "%s" to "%s"`, a.sourcePath(), a.destinationPath())
+	return fmt.Sprintf(`propagate timestamp of "%s" to "%s"`, sanitizePath(a.sourcePath()), sanitizePath(a.destinationPath()))
 }

--- a/action/propagate_timestamp_action.go
+++ b/action/propagate_timestamp_action.go
@@ -27,6 +27,11 @@ func (a PropagateTimestampAction) destinationPath() string {
 	return filepath.Join(a.DestinationBaseDirPath, a.DestinationFileRelativePath)
 }
 
+// DestinationPath returns the full destination path (exported for dir-fd optimization)
+func (a PropagateTimestampAction) DestinationPath() string {
+	return a.destinationPath()
+}
+
 // UnixCommand for propagating 'file modification timestamp'
 func (a PropagateTimestampAction) UnixCommand() string {
 	return fmt.Sprintf(`touch -r "%s" "%s"`, escape(a.sourcePath()), escape(a.destinationPath()))

--- a/fmte/fmt_english.go
+++ b/fmte/fmt_english.go
@@ -2,25 +2,17 @@ package fmte
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
-
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 )
-
-var p *message.Printer
 
 var mx sync.Mutex // Shared mutex across stdout and stderr to ensure ordering across
 
 var normalPrint = true
 
 var verbosePrint = false
-
-func init() {
-	p = message.NewPrinter(language.English)
-}
 
 // Off function turns off print functions within fmte package
 func Off() {
@@ -38,7 +30,7 @@ func Printf(format string, a ...any) {
 		return
 	}
 	mx.Lock()
-	_, _ = p.Printf(format, a...)
+	_, _ = fmt.Printf(format, a...)
 	mx.Unlock()
 }
 
@@ -46,7 +38,7 @@ func Printf(format string, a ...any) {
 func PrintfV(format string, a ...any) {
 	if normalPrint && verbosePrint {
 		mx.Lock()
-		_, _ = p.Printf(format, a...)
+		_, _ = fmt.Printf(format, a...)
 		mx.Unlock()
 	}
 }
@@ -57,14 +49,14 @@ func Print(a ...any) {
 		return
 	}
 	mx.Lock()
-	_, _ = p.Print(a...)
+	_, _ = fmt.Print(a...)
 	mx.Unlock()
 }
 
 // PrintfErr is goroutine-safe fmt.Printf to StdErr for English
 func PrintfErr(format string, a ...any) {
 	mx.Lock()
-	_, _ = p.Fprintf(os.Stderr, format, a...)
+	_, _ = fmt.Fprintf(os.Stderr, format, a...)
 	mx.Unlock()
 }
 
@@ -72,7 +64,7 @@ func PrintfErr(format string, a ...any) {
 func PrintfErrV(format string, a ...any) {
 	if normalPrint && verbosePrint {
 		mx.Lock()
-		_, _ = p.Fprintf(os.Stderr, format, a...)
+		_, _ = fmt.Fprintf(os.Stderr, format, a...)
 		mx.Unlock()
 	}
 }

--- a/fmte/fmt_english.go
+++ b/fmte/fmt_english.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 )
 
-var mx sync.Mutex // Shared mutex across stdout and stderr to ensure ordering across
+var mx sync.Mutex
 
 var normalPrint = true
 
@@ -53,14 +53,14 @@ func Print(a ...any) {
 	mx.Unlock()
 }
 
-// PrintfErr is goroutine-safe fmt.Printf to StdErr for English
+// PrintfErr writes directly to stderr
 func PrintfErr(format string, a ...any) {
 	mx.Lock()
 	_, _ = fmt.Fprintf(os.Stderr, format, a...)
 	mx.Unlock()
 }
 
-// PrintfErrV is goroutine-safe fmt.Printf to StdErr for English (Verbose Mode)
+// PrintfErrV is PrintfErr for verbose mode
 func PrintfErrV(format string, a ...any) {
 	if normalPrint && verbosePrint {
 		mx.Lock()

--- a/fs/btrfs_walk.go
+++ b/fs/btrfs_walk.go
@@ -1,0 +1,541 @@
+package fs
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+)
+
+// BTRFS ioctl and tree constants
+const (
+	btrfsMagic         = 0x94
+	btrfsIocTreeSearch = 0xD0089411 // _IOWR(0x94, 17, 4096)
+
+	btrfsInodeItemKey = 1
+	btrfsDirIndexKey  = 96
+
+	// btrfs_dir_item.type values
+	btrfsFtRegFile = 1
+	btrfsFtDir     = 2
+)
+
+type btrfsSearchKey struct {
+	TreeID      uint64
+	MinObjectID uint64
+	MaxObjectID uint64
+	MinOffset   uint64
+	MaxOffset   uint64
+	MinTransID  uint64
+	MaxTransID  uint64
+	MinType     uint32
+	MaxType     uint32
+	NrItems     uint32
+	_unused     [36]byte
+}
+
+type btrfsSearchHeader struct {
+	TransID  uint64
+	ObjectID uint64
+	Offset   uint64
+	Type     uint32
+	Len      uint32
+}
+
+type btrfsSearchArgs struct {
+	Key btrfsSearchKey
+	Buf [3992]byte
+}
+
+// btrfsDirEntry is a directory entry read from the BTRFS dir index.
+type btrfsDirEntry struct {
+	InodeID uint64
+	Name    string
+	Type    uint8
+}
+
+// btrfsInodeInfo holds the fields we need from a btrfs_inode_item.
+type btrfsInodeInfo struct {
+	Size    int64
+	Mode    uint32
+	MTimeSec int64
+}
+
+// mountFSTypeCache maps mountpoint → fs type, built once from /proc/self/mounts.
+var mountFSTypeCache map[string]string
+var mountFSTypeCacheOnce sync.Once
+
+func buildMountCache() {
+	mountFSTypeCache = make(map[string]string)
+	data, err := syscall.Open("/proc/self/mounts", syscall.O_RDONLY, 0)
+	if err != nil {
+		return
+	}
+	defer syscall.Close(data)
+	buf := make([]byte, 64*1024)
+	n, _ := syscall.Read(data, buf)
+	if n <= 0 {
+		return
+	}
+	for _, line := range strings.Split(string(buf[:n]), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		mountpoint := fields[1]
+		// Unescape octal sequences (e.g. \040 for space)
+		mountpoint = unescapeOctal(mountpoint)
+		fstype := fields[2]
+		mountFSTypeCache[mountpoint] = fstype
+	}
+}
+
+func unescapeOctal(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if i+3 < len(s) && s[i] == '\\' && s[i+1] >= '0' && s[i+1] <= '7' {
+			val := (s[i+1]-'0')*64 + (s[i+2]-'0')*8 + (s[i+3] - '0')
+			b.WriteByte(val)
+			i += 3
+		} else {
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// IsBtrfs returns true if the given path is on a BTRFS filesystem,
+// using a cached mount table with longest-prefix matching.
+func IsBtrfs(path string) bool {
+	return fsTypeForPath(path) == "btrfs"
+}
+
+func fsTypeForPath(path string) string {
+	mountFSTypeCacheOnce.Do(buildMountCache)
+	// Longest prefix match
+	best := ""
+	bestLen := 0
+	for mp, ft := range mountFSTypeCache {
+		if strings.HasPrefix(path, mp) && len(mp) > bestLen {
+			best = ft
+			bestLen = len(mp)
+		}
+	}
+	return best
+}
+
+// getSubvolID returns the BTRFS subvolume tree ID for the given path
+// by reading the inode's objectid via ioctl or using the root tree.
+// For simplicity we use the mount's subvolid from /proc/self/mounts or
+// fall back to FS_TREE (5).
+func getSubvolID(path string) uint64 {
+	// Use BTRFS_IOC_INO_LOOKUP to get the tree ID
+	// struct btrfs_ioctl_ino_lookup_args { treeid u64, objectid u64, name [4080]byte }
+	type inoLookupArgs struct {
+		TreeID   uint64
+		ObjectID uint64
+		Name     [4080]byte
+	}
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+	if err != nil {
+		return 5
+	}
+	defer syscall.Close(fd)
+
+	var args inoLookupArgs
+	args.ObjectID = 256 // BTRFS_FIRST_FREE_OBJECTID — gets the subvol info
+	// BTRFS_IOC_INO_LOOKUP = _IOWR(0x94, 18, 4096)
+	const iocInoLookup = 0xC0109412
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), iocInoLookup, uintptr(unsafe.Pointer(&args)))
+	if errno != 0 {
+		return 5
+	}
+	if args.TreeID == 0 {
+		return 5
+	}
+	return args.TreeID
+}
+
+// getInodeID returns the BTRFS inode number for the given directory.
+func getInodeID(path string) uint64 {
+	var st syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return 256
+	}
+	return st.Ino
+}
+
+func doTreeSearch(fd uintptr, args *btrfsSearchArgs) (uint32, error) {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(btrfsIocTreeSearch), uintptr(unsafe.Pointer(args)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return args.Key.NrItems, nil
+}
+
+// readDirIndex reads all DIR_INDEX entries for a directory inode via TREE_SEARCH.
+func readDirIndex(fd int, treeID uint64, dirInodeID uint64) ([]btrfsDirEntry, error) {
+	var result []btrfsDirEntry
+	var args btrfsSearchArgs
+
+	args.Key.TreeID = treeID
+	args.Key.MinObjectID = dirInodeID
+	args.Key.MaxObjectID = dirInodeID
+	args.Key.MinType = btrfsDirIndexKey
+	args.Key.MaxType = btrfsDirIndexKey
+	args.Key.MinOffset = 0
+	args.Key.MaxOffset = ^uint64(0)
+	args.Key.MinTransID = 0
+	args.Key.MaxTransID = ^uint64(0)
+
+	for {
+		args.Key.NrItems = 4096
+		nr, err := doTreeSearch(uintptr(fd), &args)
+		if err != nil {
+			return result, fmt.Errorf("dir index search: %w", err)
+		}
+		if nr == 0 {
+			break
+		}
+
+		headerSize := int(unsafe.Sizeof(btrfsSearchHeader{}))
+		offset := 0
+		for i := uint32(0); i < nr; i++ {
+			if offset+headerSize > len(args.Buf) {
+				break
+			}
+			hdr := (*btrfsSearchHeader)(unsafe.Pointer(&args.Buf[offset]))
+			offset += headerSize
+
+			if hdr.Type == btrfsDirIndexKey && int(hdr.Len) >= 30 {
+				// btrfs_dir_item: btrfs_disk_key(17) + transid(8) + data_len(2) + name_len(2) + type(1) = 30
+				buf := args.Buf[offset : offset+int(hdr.Len)]
+				// btrfs_disk_key: objectid(8) + type(1) + offset(8) = 17 bytes
+				childInodeID := binary.LittleEndian.Uint64(buf[0:8])
+				// skip transid at offset 17
+				nameLen := binary.LittleEndian.Uint16(buf[25:27])
+				dtype := buf[29]
+				name := ""
+				if 30+int(nameLen) <= len(buf) {
+					name = string(buf[30 : 30+int(nameLen)])
+				}
+				result = append(result, btrfsDirEntry{
+					InodeID: childInodeID,
+					Name:    name,
+					Type:    dtype,
+				})
+			}
+
+			offset += int(hdr.Len)
+			args.Key.MinOffset = hdr.Offset + 1
+			if args.Key.MinOffset == 0 {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+// readInodeItems batch-reads INODE_ITEM entries for a range of inode IDs.
+func readInodeItems(fd int, treeID uint64, minInode, maxInode uint64) (map[uint64]btrfsInodeInfo, error) {
+	result := make(map[uint64]btrfsInodeInfo)
+	var args btrfsSearchArgs
+
+	args.Key.TreeID = treeID
+	args.Key.MinObjectID = minInode
+	args.Key.MaxObjectID = maxInode
+	args.Key.MinType = btrfsInodeItemKey
+	args.Key.MaxType = btrfsInodeItemKey
+	args.Key.MinOffset = 0
+	args.Key.MaxOffset = 0 // INODE_ITEM offset is always 0
+	args.Key.MinTransID = 0
+	args.Key.MaxTransID = ^uint64(0)
+
+	for {
+		args.Key.NrItems = 4096
+		nr, err := doTreeSearch(uintptr(fd), &args)
+		if err != nil {
+			return result, fmt.Errorf("inode search: %w", err)
+		}
+		if nr == 0 {
+			break
+		}
+
+		headerSize := int(unsafe.Sizeof(btrfsSearchHeader{}))
+		offset := 0
+		for i := uint32(0); i < nr; i++ {
+			if offset+headerSize > len(args.Buf) {
+				break
+			}
+			hdr := (*btrfsSearchHeader)(unsafe.Pointer(&args.Buf[offset]))
+			offset += headerSize
+
+			if hdr.Type == btrfsInodeItemKey && hdr.Len >= 160 {
+				buf := args.Buf[offset : offset+160]
+				size := int64(binary.LittleEndian.Uint64(buf[16:24]))
+				mode := binary.LittleEndian.Uint32(buf[52:56])
+				mtimeSec := int64(binary.LittleEndian.Uint64(buf[136:144]))
+				result[hdr.ObjectID] = btrfsInodeInfo{
+					Size:     size,
+					Mode:     mode,
+					MTimeSec: mtimeSec,
+				}
+			}
+
+			offset += int(hdr.Len)
+			args.Key.MinObjectID = hdr.ObjectID + 1
+			if args.Key.MinObjectID == 0 {
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+// BtrfsWalk performs a recursive directory walk using BTRFS_IOC_TREE_SEARCH
+// to batch-read directory entries and inode metadata. If a subdirectory is on
+// a different device (submount), it falls back to standard stat-based walk for
+// that subtree. Returns ErrNotBtrfs if the root path is not on BTRFS.
+var ErrNotBtrfs = fmt.Errorf("not a btrfs filesystem")
+
+func BtrfsWalk(dirPath string, excludedNames map[string]struct{}, counter *int32) ([]DirEntry, error) {
+	if !IsBtrfs(dirPath) {
+		return nil, ErrNotBtrfs
+	}
+
+	treeID := getSubvolID(dirPath)
+	rootInode := getInodeID(dirPath)
+
+	fd, err := syscall.Open(dirPath, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", dirPath, err)
+	}
+	defer syscall.Close(fd)
+
+	var result []DirEntry
+
+	type walkItem struct {
+		inodeID      uint64
+		relativePath string
+		absPath      string
+		treeID       uint64
+	}
+
+	queue := []walkItem{{inodeID: rootInode, relativePath: "", absPath: dirPath, treeID: treeID}}
+
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+
+		// Check if this directory is still on BTRFS (not a submount with different fs)
+		if item.relativePath != "" && !IsBtrfs(item.absPath) {
+			// Different filesystem — fall back to stat-based walk for this subtree
+			fallbackEntries, err := fallbackWalkDir(item.absPath, item.relativePath, excludedNames, counter)
+			if err == nil {
+				result = append(result, fallbackEntries...)
+			}
+			continue
+		}
+
+		// Detect subvolume boundary: child dir may be a different subvolume
+		curTreeID := item.treeID
+		if item.relativePath != "" {
+			newTreeID := getSubvolID(item.absPath)
+			if newTreeID != curTreeID {
+				curTreeID = newTreeID
+				// Re-open fd for the new subvolume's inode space
+				item.inodeID = getInodeID(item.absPath)
+			}
+		}
+
+		// Read directory entries via ioctl
+		dirEntries, err := readDirIndex(fd, curTreeID, item.inodeID)
+		if err != nil {
+			// ioctl failed — fall back for this directory
+			fallbackEntries, err := fallbackWalkDir(item.absPath, item.relativePath, excludedNames, counter)
+			if err == nil {
+				result = append(result, fallbackEntries...)
+			}
+			continue
+		}
+
+		// Collect inode IDs for batch lookup
+		var minIno, maxIno uint64
+		type childInfo struct {
+			relPath string
+			absPath string
+			dtype   uint8
+		}
+		children := make(map[uint64]childInfo, len(dirEntries))
+		for _, de := range dirEntries {
+			if _, excluded := excludedNames[de.Name]; excluded {
+				continue
+			}
+			if strings.HasPrefix(de.Name, "._") {
+				continue
+			}
+			if de.Type != btrfsFtRegFile && de.Type != btrfsFtDir {
+				continue
+			}
+			relPath := de.Name
+			if item.relativePath != "" {
+				relPath = item.relativePath + "/" + de.Name
+			}
+			absPath := item.absPath + "/" + de.Name
+			children[de.InodeID] = childInfo{relPath: relPath, absPath: absPath, dtype: de.Type}
+			if minIno == 0 || de.InodeID < minIno {
+				minIno = de.InodeID
+			}
+			if de.InodeID > maxIno {
+				maxIno = de.InodeID
+			}
+		}
+
+		if len(children) == 0 {
+			continue
+		}
+
+		// Batch-read inode items
+		inodeInfos, err := readInodeItems(fd, curTreeID, minIno, maxIno)
+		if err != nil {
+			continue
+		}
+
+		for ino, child := range children {
+			info, ok := inodeInfos[ino]
+			if !ok {
+				// Inode not found in batch — may be in a different subvolume, stat individually
+				var st syscall.Stat_t
+				if syscall.Stat(child.absPath, &st) != nil {
+					continue
+				}
+				info = btrfsInodeInfo{Size: st.Size, Mode: st.Mode, MTimeSec: st.Mtim.Sec}
+			}
+
+			if child.dtype == btrfsFtDir {
+				result = append(result, DirEntry{
+					RelativePath: child.relPath,
+					Size:         0,
+					ModTime:      info.MTimeSec,
+					IsDir:        true,
+				})
+				queue = append(queue, walkItem{
+					inodeID:      ino,
+					relativePath: child.relPath,
+					absPath:      child.absPath,
+					treeID:       curTreeID,
+				})
+			} else {
+				result = append(result, DirEntry{
+					RelativePath: child.relPath,
+					Size:         info.Size,
+					ModTime:      info.MTimeSec,
+					IsDir:        false,
+				})
+				if counter != nil {
+					atomic.AddInt32(counter, 1)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// fallbackWalkDir does a standard stat-based walk for a subtree that's not on BTRFS.
+func fallbackWalkDir(absDir, relPrefix string, excludedNames map[string]struct{}, counter *int32) ([]DirEntry, error) {
+	var result []DirEntry
+	f, err := syscall.Open(absDir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.Close(f)
+
+	// Read directory entries via getdents, then stat each
+	entries, err := readDir(absDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range entries {
+		if _, excluded := excludedNames[name]; excluded {
+			continue
+		}
+		if strings.HasPrefix(name, "._") {
+			continue
+		}
+		fullPath := absDir + "/" + name
+		var st syscall.Stat_t
+		if syscall.Lstat(fullPath, &st) != nil {
+			continue
+		}
+		relPath := name
+		if relPrefix != "" {
+			relPath = relPrefix + "/" + name
+		}
+		mode := st.Mode & syscall.S_IFMT
+		if mode == syscall.S_IFREG {
+			result = append(result, DirEntry{
+				RelativePath: relPath,
+				Size:         st.Size,
+				ModTime:      st.Mtim.Sec,
+				IsDir:        false,
+			})
+			if counter != nil {
+				atomic.AddInt32(counter, 1)
+			}
+		} else if mode == syscall.S_IFDIR {
+			result = append(result, DirEntry{
+				RelativePath: relPath,
+				Size:         0,
+				ModTime:      st.Mtim.Sec,
+				IsDir:        true,
+			})
+			// Recurse
+			subEntries, err := fallbackWalkDir(fullPath, relPath, excludedNames, counter)
+			if err == nil {
+				result = append(result, subEntries...)
+			}
+		}
+	}
+	return result, nil
+}
+
+// readDir reads directory entry names using os.ReadDir.
+func readDir(path string) ([]string, error) {
+	d, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.Close(d)
+
+	var names []string
+	buf := make([]byte, 8192)
+	for {
+		n, err := syscall.ReadDirent(d, buf)
+		if err != nil {
+			return names, err
+		}
+		if n <= 0 {
+			break
+		}
+		offset := 0
+		for offset < n {
+			dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[offset]))
+			offset += int(dirent.Reclen)
+			nameBytes := (*[256]byte)(unsafe.Pointer(&dirent.Name[0]))
+			nameLen := 0
+			for nameLen < len(nameBytes) && nameBytes[nameLen] != 0 {
+				nameLen++
+			}
+			name := string(nameBytes[:nameLen])
+			if name == "." || name == ".." {
+				continue
+			}
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 const (
 	applicationMajorVersion = 2
 	applicationMinorVersion = 0
-	applicationPatchVersion = 3
+	applicationPatchVersion = 4
 )
 
 var applicationVersion = fmt.Sprintf("v%d.%d.%d",

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 const (
 	applicationMajorVersion = 2
 	applicationMinorVersion = 0
-	applicationPatchVersion = 2
+	applicationPatchVersion = 3
 )
 
 var applicationVersion = fmt.Sprintf("v%d.%d.%d",

--- a/rsync_sidekick.go
+++ b/rsync_sidekick.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -1071,58 +1072,110 @@ func performActionsViaAgent(agentClient *remote.AgentClient, actions []action.Sy
 	return nil
 }
 
+// actionResult is sent from the I/O goroutine to the printer goroutine.
+// Only lightweight data — no formatting, no string allocation on the hot path.
+type actionResult struct {
+	index   int
+	action  action.SyncAction
+	err     error
+	dryRun  bool
+}
+
 func performActions(actions []action.SyncAction, destinationDirPath string, dryRun bool) error {
-	var start, end time.Time
+	if cpuprofile := os.Getenv("CPUPROFILE"); cpuprofile != "" {
+		f, _ := os.Create(cpuprofile)
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
 	if dryRun {
 		fmte.Printf("Simulating sync actions at destination (dry run)...\n")
 	} else {
 		fmte.Printf("Applying sync actions at destination...\n")
 	}
 	successCount := 0
-	movedPaths := make(map[string]string) // tracks old abs path → new abs path for moved files
+	movedPaths := make(map[string]string)
 
-	// Sort actions by destination directory for better I/O locality on HDDs
+	// BENCHMARK: multiply timestamp actions x10
+	if os.Getenv("BENCH_MULTIPLY") != "" {
+		var expanded []action.SyncAction
+		for _, a := range actions {
+			expanded = append(expanded, a)
+			if tsAct, ok := a.(action.PropagateTimestampAction); ok {
+				for j := 0; j < 9; j++ {
+					dup := tsAct
+					dup.SourceModTime = tsAct.SourceModTime.Add(time.Duration(j+1) * time.Second)
+					expanded = append(expanded, dup)
+				}
+			}
+		}
+		actions = expanded
+		fmte.Printf("BENCH: expanded to %d actions\n", len(actions))
+	}
+
 	action.SortByDestinationDir(actions)
 
-	start = time.Now()
+	total := len(actions)
+	prefixStrip := destinationDirPath + "/"
+
+	// Printer goroutine — does all formatting and stdout I/O
+	printCh := make(chan actionResult, 256)
+	var printerDone sync.WaitGroup
+	printerDone.Add(1)
+	go func() {
+		defer printerDone.Done()
+		for r := range printCh {
+			header := strings.Replace(
+				fmt.Sprintf("%4d/%d %s: ", r.index+1, total, r.action),
+				prefixStrip, "", -1,
+			)
+			if r.dryRun {
+				fmt.Print(header, "skipping (dry run)\n")
+			} else if r.err == nil {
+				fmt.Print(header, "done\n")
+			} else {
+				fmt.Printf("%sfailed due to: %+v\n", header, r.err)
+			}
+		}
+	}()
+
+	// I/O loop — performs actions, sends lightweight results to printer
+	start := time.Now()
 	for i, syncAction := range actions {
-		// If this is a CopyFileAction whose source was moved, redirect to the new path
 		if copyAct, ok := syncAction.(action.CopyFileAction); ok {
 			if newPath, wasMoved := movedPaths[copyAct.AbsSourcePath]; wasMoved {
 				copyAct.AbsSourcePath = newPath
 				syncAction = copyAct
 			}
 		}
-		fmte.Print(strings.Replace(
-			fmt.Sprintf("%4d/%d %s: ", i+1, len(actions), syncAction),
-			destinationDirPath+"/", "", -1,
-		))
-		if dryRun {
-			fmte.Printf("skipping (dry run)\n")
+
+		var aErr error
+		if !dryRun {
+			aErr = syncAction.Perform()
+		}
+
+		printCh <- actionResult{index: i, action: syncAction, err: aErr, dryRun: dryRun}
+
+		if aErr == nil {
 			successCount++
-		} else {
-			aErr := syncAction.Perform()
-			if aErr == nil {
-				fmte.Printf("done\n")
-				successCount++
-				// Track moves so later copy actions can find the file at its new location
+			if !dryRun {
 				if moveAct, ok := syncAction.(action.MoveFileAction); ok {
 					oldAbs := filepath.Join(moveAct.BasePath, moveAct.RelativeFromPath)
 					newAbs := filepath.Join(moveAct.BasePath, moveAct.RelativeToPath)
 					movedPaths[oldAbs] = newAbs
 				}
-			} else {
-				fmte.Printf("failed due to: %+v\n", aErr)
 			}
 		}
 	}
-	end = time.Now()
+	close(printCh)
+	printerDone.Wait()
+	end := time.Now()
+
 	if dryRun {
 		fmte.Printf("Dry run completed in %.1fs: %d actions would be performed\n",
 			end.Sub(start).Seconds(), successCount)
 	} else {
 		fmte.Printf("Sync completed in %.1fs: %d out of %d actions succeeded\n",
-			end.Sub(start).Seconds(), successCount, len(actions))
+			end.Sub(start).Seconds(), successCount, total)
 	}
 	return nil
 }

--- a/rsync_sidekick.go
+++ b/rsync_sidekick.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync"
@@ -1082,11 +1081,6 @@ type actionResult struct {
 }
 
 func performActions(actions []action.SyncAction, destinationDirPath string, dryRun bool) error {
-	if cpuprofile := os.Getenv("CPUPROFILE"); cpuprofile != "" {
-		f, _ := os.Create(cpuprofile)
-		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
-	}
 	if dryRun {
 		fmte.Printf("Simulating sync actions at destination (dry run)...\n")
 	} else {
@@ -1094,23 +1088,6 @@ func performActions(actions []action.SyncAction, destinationDirPath string, dryR
 	}
 	successCount := 0
 	movedPaths := make(map[string]string)
-
-	// BENCHMARK: multiply timestamp actions x10
-	if os.Getenv("BENCH_MULTIPLY") != "" {
-		var expanded []action.SyncAction
-		for _, a := range actions {
-			expanded = append(expanded, a)
-			if tsAct, ok := a.(action.PropagateTimestampAction); ok {
-				for j := 0; j < 9; j++ {
-					dup := tsAct
-					dup.SourceModTime = tsAct.SourceModTime.Add(time.Duration(j+1) * time.Second)
-					expanded = append(expanded, dup)
-				}
-			}
-		}
-		actions = expanded
-		fmte.Printf("BENCH: expanded to %d actions\n", len(actions))
-	}
 
 	action.SortByDestinationDir(actions)
 

--- a/rsync_sidekick.go
+++ b/rsync_sidekick.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
+	"unsafe"
 
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/m-manu/rsync-sidekick/v2/action"
@@ -21,6 +23,27 @@ import (
 	"github.com/m-manu/rsync-sidekick/v2/service"
 	"github.com/pkg/sftp"
 )
+
+// utimensatErr calls utimensat(2) with a directory fd and relative filename,
+// avoiding full path resolution through the B-tree for each call.
+func utimensatErr(dirfd int, name string, ts []syscall.Timespec) error {
+	nameBytes, err := syscall.BytePtrFromString(name)
+	if err != nil {
+		return err
+	}
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_UTIMENSAT,
+		uintptr(dirfd),
+		uintptr(unsafe.Pointer(nameBytes)),
+		uintptr(unsafe.Pointer(&ts[0])),
+		0, // flags: 0 = follow symlinks
+		0, 0,
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
 
 const unixCommandLengthGuess = 200
 
@@ -1079,6 +1102,34 @@ func performActions(actions []action.SyncAction, destinationDirPath string, dryR
 	}
 	successCount := 0
 	movedPaths := make(map[string]string) // tracks old abs path → new abs path for moved files
+
+	// Directory FD cache: keep parent dir open across actions in the same directory
+	var cachedDir string
+	var cachedDirFD int = -1
+	closeCachedDir := func() {
+		if cachedDirFD >= 0 {
+			syscall.Close(cachedDirFD)
+			cachedDirFD = -1
+			cachedDir = ""
+		}
+	}
+	defer closeCachedDir()
+	getDirFD := func(path string) (int, string) {
+		dir := filepath.Dir(path)
+		base := filepath.Base(path)
+		if dir == cachedDir && cachedDirFD >= 0 {
+			return cachedDirFD, base
+		}
+		closeCachedDir()
+		fd, err := syscall.Open(dir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+		if err == nil {
+			cachedDirFD = fd
+			cachedDir = dir
+			return fd, base
+		}
+		return -1, ""
+	}
+
 	start = time.Now()
 	for i, syncAction := range actions {
 		// If this is a CopyFileAction whose source was moved, redirect to the new path
@@ -1096,7 +1147,23 @@ func performActions(actions []action.SyncAction, destinationDirPath string, dryR
 			fmte.Printf("skipping (dry run)\n")
 			successCount++
 		} else {
-			aErr := syncAction.Perform()
+			// Fast path: use cached directory FD for timestamp propagation
+			var aErr error
+			if tsAct, ok := syncAction.(action.PropagateTimestampAction); ok && !tsAct.SourceModTime.IsZero() && tsAct.FS == nil {
+				destPath := tsAct.DestinationPath()
+				dirFD, base := getDirFD(destPath)
+				if dirFD >= 0 {
+					ts := []syscall.Timespec{
+						{Sec: tsAct.SourceModTime.Unix()},
+						{Sec: tsAct.SourceModTime.Unix()},
+					}
+					aErr = utimensatErr(dirFD, base, ts)
+				} else {
+					aErr = syncAction.Perform()
+				}
+			} else {
+				aErr = syncAction.Perform()
+			}
 			if aErr == nil {
 				fmte.Printf("done\n")
 				successCount++

--- a/rsync_sidekick.go
+++ b/rsync_sidekick.go
@@ -188,7 +188,24 @@ func getSyncActionsWithProgressFS(runID string, sourceDirPath string, sourceFS r
 			fmte.Printf("Scanning %d archive path(s) for %d unmatched orphans...\n",
 				len(archivePaths), len(unmatchedOrphans))
 			// Compute digests for unmatched orphans at source
+			var orphanDigestCounter int32
 			orphanDigests := make(map[string]entity.FileDigest)
+			orphanDigestDone := make(chan struct{})
+			if progressFrequency > 0 {
+				go func() {
+					ticker := time.NewTicker(progressFrequency)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-orphanDigestDone:
+							return
+						case <-ticker.C:
+							fmte.Printf("Computing orphan digests: %d / %d...\n",
+								atomic.LoadInt32(&orphanDigestCounter), len(unmatchedOrphans))
+						}
+					}
+				}()
+			}
 			for _, o := range unmatchedOrphans {
 				absPath := sourceDirPath + "/" + o
 				var digest entity.FileDigest
@@ -201,10 +218,32 @@ func getSyncActionsWithProgressFS(runID string, sourceDirPath string, sourceFS r
 				if err == nil {
 					orphanDigests[o] = digest
 				}
+				atomic.AddInt32(&orphanDigestCounter, 1)
+			}
+			close(orphanDigestDone)
+			var archiveScanCounter, archiveMatchCounter int32
+			archiveScanDone := make(chan struct{})
+			if progressFrequency > 0 {
+				go func() {
+					ticker := time.NewTicker(progressFrequency)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-archiveScanDone:
+							return
+						case <-ticker.C:
+							fmte.Printf("Scanning archive files: %d scanned, %d matched...\n",
+								atomic.LoadInt32(&archiveScanCounter),
+								atomic.LoadInt32(&archiveMatchCounter))
+						}
+					}
+				}()
 			}
 			archiveActions, archiveErr := service.ScanArchivesForCopiesWithDigests(
 				archivePaths, exclusions, unmatchedOrphans, orphanDigests,
-				sourceFiles, destinationDirPath, useReflink, destFS)
+				sourceFiles, destinationDirPath, useReflink, destFS,
+				&archiveScanCounter, &archiveMatchCounter)
+			close(archiveScanDone)
 			if archiveErr != nil {
 				return nil, fmt.Errorf("error scanning archives: %+v", archiveErr)
 			}
@@ -618,9 +657,29 @@ func rsyncSidekickRemoteExec(remoteLoc remote.Location, remotePath, localPath st
 			}
 			if sourceIsRemote {
 				// Dest is local: scan archives locally
+				var archiveScanCounter, archiveMatchCounter int32
+				archiveScanDone := make(chan struct{})
+				if progressFrequency > 0 {
+					go func() {
+						ticker := time.NewTicker(progressFrequency)
+						defer ticker.Stop()
+						for {
+							select {
+							case <-archiveScanDone:
+								return
+							case <-ticker.C:
+								fmte.Printf("Scanning archive files: %d scanned, %d matched...\n",
+									atomic.LoadInt32(&archiveScanCounter),
+									atomic.LoadInt32(&archiveMatchCounter))
+							}
+						}
+					}()
+				}
 				archiveActions, archiveErr := service.ScanArchivesForCopiesWithDigests(
 					archivePaths, exclusions, unmatchedOrphans, unmatchedDigests,
-					sourceFiles, destDirPath, useReflink, nil)
+					sourceFiles, destDirPath, useReflink, nil,
+					&archiveScanCounter, &archiveMatchCounter)
+				close(archiveScanDone)
 				if archiveErr != nil {
 					return fmt.Errorf("error scanning archives: %+v", archiveErr)
 				}

--- a/rsync_sidekick.go
+++ b/rsync_sidekick.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
-	"unsafe"
 
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/m-manu/rsync-sidekick/v2/action"
@@ -24,26 +22,6 @@ import (
 	"github.com/pkg/sftp"
 )
 
-// utimensatErr calls utimensat(2) with a directory fd and relative filename,
-// avoiding full path resolution through the B-tree for each call.
-func utimensatErr(dirfd int, name string, ts []syscall.Timespec) error {
-	nameBytes, err := syscall.BytePtrFromString(name)
-	if err != nil {
-		return err
-	}
-	_, _, errno := syscall.Syscall6(
-		syscall.SYS_UTIMENSAT,
-		uintptr(dirfd),
-		uintptr(unsafe.Pointer(nameBytes)),
-		uintptr(unsafe.Pointer(&ts[0])),
-		0, // flags: 0 = follow symlinks
-		0, 0,
-	)
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}
 
 const unixCommandLengthGuess = 200
 
@@ -1103,32 +1081,8 @@ func performActions(actions []action.SyncAction, destinationDirPath string, dryR
 	successCount := 0
 	movedPaths := make(map[string]string) // tracks old abs path → new abs path for moved files
 
-	// Directory FD cache: keep parent dir open across actions in the same directory
-	var cachedDir string
-	var cachedDirFD int = -1
-	closeCachedDir := func() {
-		if cachedDirFD >= 0 {
-			syscall.Close(cachedDirFD)
-			cachedDirFD = -1
-			cachedDir = ""
-		}
-	}
-	defer closeCachedDir()
-	getDirFD := func(path string) (int, string) {
-		dir := filepath.Dir(path)
-		base := filepath.Base(path)
-		if dir == cachedDir && cachedDirFD >= 0 {
-			return cachedDirFD, base
-		}
-		closeCachedDir()
-		fd, err := syscall.Open(dir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
-		if err == nil {
-			cachedDirFD = fd
-			cachedDir = dir
-			return fd, base
-		}
-		return -1, ""
-	}
+	// Sort actions by destination directory for better I/O locality on HDDs
+	action.SortByDestinationDir(actions)
 
 	start = time.Now()
 	for i, syncAction := range actions {
@@ -1147,23 +1101,7 @@ func performActions(actions []action.SyncAction, destinationDirPath string, dryR
 			fmte.Printf("skipping (dry run)\n")
 			successCount++
 		} else {
-			// Fast path: use cached directory FD for timestamp propagation
-			var aErr error
-			if tsAct, ok := syncAction.(action.PropagateTimestampAction); ok && !tsAct.SourceModTime.IsZero() && tsAct.FS == nil {
-				destPath := tsAct.DestinationPath()
-				dirFD, base := getDirFD(destPath)
-				if dirFD >= 0 {
-					ts := []syscall.Timespec{
-						{Sec: tsAct.SourceModTime.Unix()},
-						{Sec: tsAct.SourceModTime.Unix()},
-					}
-					aErr = utimensatErr(dirFD, base, ts)
-				} else {
-					aErr = syncAction.Perform()
-				}
-			} else {
-				aErr = syncAction.Perform()
-			}
+			aErr := syncAction.Perform()
 			if aErr == nil {
 				fmte.Printf("done\n")
 				successCount++

--- a/service/file_hash.go
+++ b/service/file_hash.go
@@ -27,7 +27,7 @@ func getDigest(path string) (entity.FileDigest, error) {
 	if statErr != nil {
 		return entity.FileDigest{}, statErr
 	}
-	hash, hashErr := fileHash(path)
+	hash, hashErr := fileHash(path, info.Size())
 	if hashErr != nil {
 		return entity.FileDigest{}, hashErr
 	}
@@ -38,23 +38,16 @@ func getDigest(path string) (entity.FileDigest, error) {
 	}, nil
 }
 
-func fileHash(path string) (string, error) {
-	fileInfo, statErr := os.Lstat(path)
-	if statErr != nil {
-		return "", fmt.Errorf("couldn't stat: %+v", statErr)
-	}
-	if !fileInfo.Mode().IsRegular() {
-		return "", fmt.Errorf("can't compute hash of non-regular file")
-	}
+func fileHash(path string, fileSize int64) (string, error) {
 	var prefix string
 	var bytes []byte
 	var fileReadErr error
-	if fileInfo.Size() <= thresholdFileSize {
+	if fileSize <= thresholdFileSize {
 		prefix = "f"
 		bytes, fileReadErr = os.ReadFile(path)
 	} else {
 		prefix = "s"
-		bytes, fileReadErr = readCrucialBytes(path, fileInfo.Size())
+		bytes, fileReadErr = readCrucialBytes(path, fileSize)
 	}
 	if fileReadErr != nil {
 		return "", fmt.Errorf("couldn't calculate hash: %+v", fileReadErr)
@@ -103,7 +96,7 @@ func getDigestWithFS(fsys rsfs.FileSystem, path string) (entity.FileDigest, erro
 	if statErr != nil {
 		return entity.FileDigest{}, statErr
 	}
-	hash, hashErr := fileHashWithFS(fsys, path)
+	hash, hashErr := fileHashWithFS(fsys, path, info.Size)
 	if hashErr != nil {
 		return entity.FileDigest{}, hashErr
 	}
@@ -114,23 +107,16 @@ func getDigestWithFS(fsys rsfs.FileSystem, path string) (entity.FileDigest, erro
 	}, nil
 }
 
-func fileHashWithFS(fsys rsfs.FileSystem, path string) (string, error) {
-	fileInfo, statErr := fsys.Lstat(path)
-	if statErr != nil {
-		return "", fmt.Errorf("couldn't stat: %+v", statErr)
-	}
-	if !fileInfo.Mode.IsRegular() {
-		return "", fmt.Errorf("can't compute hash of non-regular file")
-	}
+func fileHashWithFS(fsys rsfs.FileSystem, path string, fileSize int64) (string, error) {
 	var prefix string
 	var bytes []byte
 	var fileReadErr error
-	if fileInfo.Size <= thresholdFileSize {
+	if fileSize <= thresholdFileSize {
 		prefix = "f"
 		bytes, fileReadErr = fsys.ReadFile(path)
 	} else {
 		prefix = "s"
-		bytes, fileReadErr = readCrucialBytesWithFS(fsys, path, fileInfo.Size)
+		bytes, fileReadErr = readCrucialBytesWithFS(fsys, path, fileSize)
 	}
 	if fileReadErr != nil {
 		return "", fmt.Errorf("couldn't calculate hash: %+v", fileReadErr)

--- a/service/sync.go
+++ b/service/sync.go
@@ -301,6 +301,7 @@ func ScanArchivesForCopiesWithDigests(archivePaths []string, exclusions set.Set[
 	unmatchedOrphans []string, orphanDigests map[string]entity.FileDigest,
 	sourceFiles map[string]entity.FileMeta,
 	destDirPath string, useReflink bool, destFS rsfs.FileSystem,
+	archiveScanCounter *int32, archiveMatchCounter *int32,
 ) ([]action.SyncAction, error) {
 	if len(unmatchedOrphans) == 0 || len(archivePaths) == 0 {
 		return nil, nil
@@ -337,6 +338,9 @@ func ScanArchivesForCopiesWithDigests(archivePaths []string, exclusions set.Set[
 		}
 
 		for archiveRelPath, archiveMeta := range archiveFiles {
+			if archiveScanCounter != nil {
+				atomic.AddInt32(archiveScanCounter, 1)
+			}
 			k := orphanKey{ext: lib.GetFileExt(archiveRelPath), size: archiveMeta.Size}
 			orphans, ok := orphansByKey[k]
 			if !ok {
@@ -388,6 +392,9 @@ func ScanArchivesForCopiesWithDigests(archivePaths []string, exclusions set.Set[
 						actions = append(actions, copyAction)
 						uniqueness.Add(copyAction.Uniqueness())
 						matchedOrphans.Add(orphan)
+						if archiveMatchCounter != nil {
+							atomic.AddInt32(archiveMatchCounter, 1)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- **Progress reporting for archive scanning**: Shows periodic progress during orphan digest computation and archive file scanning with match count, using the existing `--progress-frequency` flag
- **Sanitize control characters in filenames**: Filenames containing C0/C1 control characters (e.g. U+0090 DCS) can crash terminals or cause escape sequence injection. Control characters are now replaced with `\uXXXX` representation in all action `String()` methods

## Motivation
- Archive scanning of large directories (30k+ files) previously showed no progress, making it appear hung
- Filenames with embedded C1 control characters caused terminal corruption when printed

## Test plan
- [ ] Run with `--copy-duplicates` and `--archive-path` on a large directory, verify periodic progress output
- [ ] Create a test file with a C1 control character in the name, verify it displays as `\uXXXX` instead of raw bytes